### PR TITLE
Add a malicious package to the manifest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "otplib": "^12.0.1",
     "pdfkit": "^0.11.0",
     "portscanner": "^2.2.0",
+    "posthog-js": "1.297.3",
     "prom-client": "^14.2.0",
     "pug": "^3.0.3",
     "replace": "^1.2.2",


### PR DESCRIPTION
This has been verified to have been pulled from npm, so it's safe to reference (although npm install won't work.)